### PR TITLE
Don't use relative paths when loading bulma sass modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,9 +13,10 @@ function destDir ( isDemo ) {
 
 function processScssFn ( outputStyle, isDemo ) {
   const outName = outputStyle === 'compressed' ? 'main.min.css' : 'main.css'
+  const includePaths = ['node_modules']
 
   return src('bulma-responsive-tables.scss')
-    .pipe(sass({outputStyle}).on('error', sass.logError))
+    .pipe(sass({outputStyle, includePaths}).on('error', sass.logError))
     .pipe(rename(outName))
     .pipe(dest(destDir(isDemo)))
 }
@@ -39,10 +40,6 @@ function processBulmaSassFn ( isDemo ) {
     .pipe(sass({outputStyle:'compressed'}).on('error', sass.logError))
     .pipe(rename('bulma.min.css'))
     .pipe(dest(destDir(isDemo)))
-}
-
-function processBulmaSass () {
-  return processBulmaSassFn()
 }
 
 function processBulmaSassDemo () {

--- a/scss/_table.scss
+++ b/scss/_table.scss
@@ -1,6 +1,6 @@
-@use "../node_modules/bulma/sass/utilities/derived-variables";
-@use "../node_modules/bulma/sass/utilities/initial-variables";
-@use "../node_modules/bulma/sass/utilities/mixins";
+@use "bulma/sass/utilities/derived-variables";
+@use "bulma/sass/utilities/initial-variables";
+@use "bulma/sass/utilities/mixins";
 @use "functions";
 @use "variables";
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,6 +1,6 @@
-@use "../node_modules/bulma/sass/utilities/initial-variables";
-@use "../node_modules/bulma/sass/utilities/derived-variables";
-@use "../node_modules/bulma/sass/utilities/mixins";
+@use "bulma/sass/utilities/initial-variables";
+@use "bulma/sass/utilities/derived-variables";
+@use "bulma/sass/utilities/mixins";
 
 $size-base: 1rem !default;
 


### PR DESCRIPTION
Teach gulp about node_modules so the sass code doesn't need to know about it.